### PR TITLE
Bugfix/get context obj name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ to match an existing, running Servicenow Instance.
     - Replace `(snow_user)` and `(snow_password)` values with your Servicenow's user and password.
     - Replace `(proxy_url)` with your instance's proxy url, or leave blank if there is none.
 
-  **NOTE** values are used in `"https://#{snow_server}/api/now/table/#{table_name}"`, so make sure to leave
+  > **NOTE** values are used in `"https://#{snow_server}/api/now/table/#{table_name}"`, so make sure to leave
   out the https:// and any endpoints from the `(snow_server)` value.
 
-  **NOTE** make sure to select automate instances, as there should be an automate instance and an automate method with the same name.
+  > **NOTE** make sure to select automate instances, as there should be an automate instance and an automate method with the same name.
 
 ### Creating ServiceNow Incident Generic Object
 
@@ -75,7 +75,7 @@ to match an existing, running Servicenow Instance.
     - ***assignment\_group***: "String",
     - ***created\_by***: "String",
   - Click `Add`.
-  - ***NOTE***: The object's attributes match the ***Incident***'s attributes, they may be changed, but then the `create.rb` method should be updated accordingly.
+  > ***NOTE***: The object's attributes match the ***Incident***'s attributes, they may be changed, but then the `create.rb` method should be updated accordingly.
   
 
 ### Importing the dialogs for the ServiceNow datastore methods

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ to match an existing, running Servicenow Instance.
 
   - Click `Add`.
 
+  > When creating the button, you may specify expressions that define where the button is enabled or visible.
+  >
+  > Example - creating a button on a Physical Server with name `physical-server-1`:
+  >  * During the button creation under the `Advanced` tab:
+  >    * Under `Visibility / Edit Selected Element` select `Field`.
+  >    * Another dropdown should appear, select `Physical Server:Name`.
+  >    * Another dropdown and text box should appear; In dropdown, select `REGULAR EXPRESSION MATCHES`, and in text box insert `physical-server-1`.
+  >    * Click `Commit`.
+
 ### Creating ServiceNow catalog
 
 - Navigate to `Services -> Catalogs`.

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ to match an existing, running Servicenow Instance.
     - Replace `(snow_user)` and `(snow_password)` values with your Servicenow's user and password.
     - Replace `(proxy_url)` with your instance's proxy url, or leave blank if there is none.
 
-  > **NOTE** values are used in `"https://#{snow_server}/api/now/table/#{table_name}"`, so make sure to leave
-  out the https:// and any endpoints from the `(snow_server)` value.
 
-  > **NOTE** make sure to select automate instances, as there should be an automate instance and an automate method with the same name.
+  > **NOTE** 
+  > 1. values are used in `"https://#{snow_server}/api/now/table/#{table_name}"`, so make sure to leave
+  out the https:// and any endpoints from the `(snow_server)` value.
+  >
+  > 2. make sure to select automate instances, as there should be an automate instance and an automate method with the same name.
 
 ### Creating ServiceNow Incident Generic Object
 
@@ -75,7 +77,9 @@ to match an existing, running Servicenow Instance.
     - ***assignment\_group***: "String",
     - ***created\_by***: "String",
   - Click `Add`.
-  > ***NOTE***: The object's attributes match the ***Incident***'s attributes, they may be changed, but then the `create.rb` method should be updated accordingly.
+  > ***NOTE***
+  > 
+  > The object's attributes match the ***Incident***'s attributes, they may be changed, but then the `create.rb` method should    be updated accordingly.
   
 
 ### Importing the dialogs for the ServiceNow datastore methods
@@ -113,7 +117,8 @@ to match an existing, running Servicenow Instance.
     - Under `Attribute/Value Pairs`, add the pair: ***action***: "create".
 
   - Click `Add`.
-
+  > ***NOTE***
+  >
   > When creating the button, you may specify expressions that define where the button is enabled or visible.
   >
   > Example - creating a button on a Physical Server with name `physical-server-1`:

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ Integration of ServiceNow’s CMDB management with ManageIQ
 2. [Importing ServiceNow datastore to ManageIQ](#importing-servicenow-datastore-to-manageiq)
 3. [Modifying the imported domains Instance values](#modifying-the-imported-domains-instance-values)
 4. [Creating Servicenow Incident Generic Object](#creating-servicenow-incident-generic-object)
-5. [Creating Add ServiceNow Incident Button](#creating-add-servicenow-incident-button)
-6. [Creating Servicenow catalog](#creating-servicenow-catalog)
-7. [Creating ServiceNow Create Incident Service Catalog Item](#creating-servicenow-create-incident-service-catalog-item)
-8. [Creating ServiceNow View and Update Incidents Service Catalog Item](#creating-servicenow-view-and-update-incidents-service-catalog-item)
-9. [Using ServiceNow Catalog Items and Buttons](#using-servicenow-catalog-items-and-buttons)
+5. [Importing the dialogs for the ServiceNow datastore methods](#importing-the-dialogs-for-the-servicenow-datastore-methods)
+6. [Creating Add ServiceNow Incident Button](#creating-add-servicenow-incident-button)
+7. [Creating Servicenow catalog](#creating-servicenow-catalog)
+8. [Creating ServiceNow Create Incident Service Catalog Item](#creating-servicenow-create-incident-service-catalog-item)
+9. [Creating ServiceNow View and Update Incidents Service Catalog Item](#creating-servicenow-view-and-update-incidents-service-catalog-item)
+10. [Using ServiceNow Catalog Items and Buttons](#using-servicenow-catalog-items-and-buttons)
 
 ## Prerequisites
 
 - Clone the repository and zip the `ServiceNow` directoriy.
-- Download the dialogs yaml file from [ServiceNow_Dialogs](https://github.com/xlab-si/ServiceNow_Dialogs).
+- Download the [dialogs](https://github.com/xlab-si/ServiceNow_Dialogs/blob/main/ServiceNow_Dialogs.yml) yaml file from [ServiceNow_Dialogs](https://github.com/xlab-si/ServiceNow_Dialogs).
 - Make sure you have a running instance of ManageIQ (the steps in this document are performed in ManageIQ's UI).
 - Make sure you have a running Servicenow Instance and the required credentials.
 
@@ -81,7 +82,7 @@ to match an existing, running Servicenow Instance.
 
 - Navigate to `Automation -> Embedded Automate -> Customization`.
 
-- Under `Import`, select the dialogs yaml file and click `Upload`:
+- Under `Import`, select the [dialogs](https://github.com/xlab-si/ServiceNow_Dialogs/blob/main/ServiceNow_Dialogs.yml) yaml file and click `Upload`:
 
   - Under `Import Service Dialogs`, check all the dialogs and click `Commit`.
 

--- a/ServiceNow/Integration/ServiceNow/CMDB.class/__methods__/get_context_obj_name.rb
+++ b/ServiceNow/Integration/ServiceNow/CMDB.class/__methods__/get_context_obj_name.rb
@@ -16,7 +16,7 @@ log(:info, $evm.root['vmdb_object_type'])
 log(:info, "--------------------****-------------")
 
 obj_type = $evm.root['vmdb_object_type']
-obj_name = $evm.root[obj_type]
+obj_name = $evm.root[obj_type].name
 
 log(:info, "--------------------*^^^^^***-------------#{obj_name}")
 


### PR DESCRIPTION
- Fix `get_context_obj_name` method.
  - Before the method fetched the whole object and expected it to have a string representation.
  - Now it explicitly fetches the object's `name` field.
  
- Updated instructions in README.
  - Added an example for creating a button visible only on a specific object.